### PR TITLE
Fix/user must be signed in to make api calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+#### 1.5.4 (2022-04-25)
+
+##### Chores
+
+*  fixed changelog (206e2b91)
+*  creates tag without v prefix (a38056de)
+
+##### Bug Fixes
+
+* **android:**
+  *  gets google account for context instead of last signed in account (Error: 4: The user must be signed in to make this API call.) (e2c35231)
+  *  getStepsDaily returns 7 days instead of 8 (92145406)
+
+##### Other Changes
+
+* rn-fitness-tracker/rn-fitness-tracker into fix/access-google-fit-if-tracking-is-available (857dc5b3)
+
+##### Refactors
+
+* **android:**  removed unused Log import (81ad37ca)
+
 #### 1.5.3 (2021-12-14)
 
 ##### Bug Fixes

--- a/android/src/main/java/com/fitnesstracker/GoogleFit/GoogleFitManager.java
+++ b/android/src/main/java/com/fitnesstracker/GoogleFit/GoogleFitManager.java
@@ -2,7 +2,6 @@ package com.fitnesstracker.GoogleFit;
 
 import android.app.Activity;
 import android.content.Intent;
-import android.util.Log;
 
 import com.facebook.react.bridge.ActivityEventListener;
 import com.facebook.react.bridge.Arguments;

--- a/android/src/main/java/com/fitnesstracker/GoogleFit/GoogleFitManager.java
+++ b/android/src/main/java/com/fitnesstracker/GoogleFit/GoogleFitManager.java
@@ -142,7 +142,7 @@ public class GoogleFitManager implements ActivityEventListener {
 
       Calendar cal = Calendar.getInstance();
       cal.setTime(endDate);
-      cal.add(Calendar.DATE, -7);
+      cal.add(Calendar.DATE, -6);
       Date startDate = cal.getTime();
 
       this.historyClient.getDailyStepsForNumberOfDays(startDate, endDate, Arguments.createMap(), promise);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kilohealth/rn-fitness-tracker",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "Fitness & Health tracking package for React Native for Android & iOS",
   "homepage": "https://github.com/doville/rn-fitness-tracker",
   "repository": "https://github.com/doville/rn-fitness-tracker",


### PR DESCRIPTION
## 1.5.4 (2022-04-25)

##### Chores

*  fixed changelog (206e2b91)
*  creates tag without v prefix (a38056de)

##### Bug Fixes

* **android:**
  *  gets google account for context instead of last signed in account (Error: 4: The user must be signed in to make this API call.) (e2c35231)
  *  getStepsDaily returns 7 days instead of 8 (92145406)

##### Refactors

* **android:**  removed unused Log import (81ad37ca)