### PR TITLE
fix: get rootProject values for build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,10 +1,5 @@
 buildscript {
-    ext {
-        compileSdkVersion = 30
-        kotlinVersion = "1.7.10"
-        minSdkVersion = 21
-        targetSdkVersion = 30
-    }
+    def kotlin_version = rootProject.ext.has('kotlinVersion') ? rootProject.ext.get('kotlinVersion') : "1.7.20"
 
     repositories {
         google()
@@ -13,23 +8,23 @@ buildscript {
 
     dependencies {
         classpath "com.android.tools.build:gradle:4.2.2"
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
-def getExt(name) {
-    return rootProject.ext.get(name)
+def getExtOrDefault(name, defaultValue) {
+    return rootProject.ext.has(name) ? rootProject.ext.get(name) : defaultValue
 }
 
 android {
-    compileSdkVersion getExt('compileSdkVersion')
+    compileSdkVersion getExtOrDefault('compileSdkVersion', 31)
 
     defaultConfig {
-        minSdkVersion getExt('minSdkVersion')
-        targetSdkVersion getExt('targetSdkVersion')
+        minSdkVersion getExtOrDefault('minSdkVersion', 21)
+        targetSdkVersion getExtOrDefault('targetSdkVersion', 31)
     }
 
     lintOptions {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Gets the values for build.gradle options from rootProject.

## Motivation and Context

If build.gradle options are different from rootProject it may not build.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Installed in project and ran build command.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->
<!--- Add screenshots (if appropriate) -->

### Checklist

- This is a breaking change:
  - [ ] Yes
  - [x] No
- Will this release a new version:
  - [x] Yes, minor
  - [ ] No
