### PR TITLE
ci: skip husky install in CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "main": "src/index.ts",
   "scripts": {
     "allow-bash": "chmod a+x .husky/commit-msg",
-    "postinstall": "husky install && yarn allow-bash",
+    "postinstall": "test -n \"$CI\" || husky install && yarn allow-bash",
     "prepack": "pinst --disable",
     "postpack": "pinst --enable",
     "sort-package-json": "npx sort-package-json",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Skip husky install in CI, because it is not needed and only causes problems.


### Checklist

- This is a breaking change:
  - [ ] Yes
  - [x] No
- Will this release a new version:
  - [ ] Yes
  - [x] No
