### PR TITLE
Fix/throw error if google credential setup is incorrectly

### DIFF
--- a/android/src/main/java/com/fitnesstracker/googlefit/GoogleFitManager.kt
+++ b/android/src/main/java/com/fitnesstracker/googlefit/GoogleFitManager.kt
@@ -52,19 +52,33 @@ class GoogleFitManager(private val reactContext: ReactApplicationContext) : Acti
                 authorisationPromise?.resolve(false)
             } catch (e: ApiException) {
                 val code = e.statusCode
-                val errorCodeMessage = "ErrorCode: $code; "
-                println(errorCodeMessage)
-                if (e.statusCode == 10 || e.statusCode == 12500) {
+
+                if (code == SIGN_IN_CANCELLED_CODE) {
+                    authorisationPromise?.resolve(false)
+                    return
+                }
+
+                if (code == SIGN_IN_FAILED_CODE) {
+                    authorisationPromise?.reject(
+                        E_SIGN_IN_FAILED,
+                        SIGN_IN_FAILED_ERROR_MESSAGE
+                    )
+                    return
+                }
+
+                if (code == DEVELOPER_ERROR_CODE) {
                     authorisationPromise?.reject(
                         E_DEVELOPER_ERROR,
-                        errorCodeMessage + E_DEVELOPER_ERROR_MESSAGE
+                        DEVELOPER_ERROR_MESSAGE
                     )
-                } else {
-                    authorisationPromise?.reject(
-                        E_UNKNOWN_ERROR,
-                        errorCodeMessage + E_UNKNOWN_ERROR_MESSAGE
-                    )
+                    return
                 }
+
+                val errorCodeMessage = "ErrorCode: $code; "
+                authorisationPromise?.reject(
+                    E_UNKNOWN_ERROR,
+                    errorCodeMessage + E_UNKNOWN_ERROR_MESSAGE
+                )
             }
         }
     }
@@ -134,11 +148,17 @@ class GoogleFitManager(private val reactContext: ReactApplicationContext) : Acti
     }
 
     companion object {
+        private const val GOOGLE_FIT_PERMISSIONS_REQUEST_CODE = 111
+        private const val DEVELOPER_ERROR_CODE = 10
         private const val E_DEVELOPER_ERROR = "E_DEVELOPER_ERROR"
-        private const val E_DEVELOPER_ERROR_MESSAGE =
-            "Developer error, please check if you correctly setup SHA1 and Package Name in the Google API console"
+        private const val DEVELOPER_ERROR_MESSAGE =
+            "Error: $DEVELOPER_ERROR_CODE; Developer error, please check if you correctly setup SHA1 and Package Name in the Google API console"
         private const val E_UNKNOWN_ERROR = "E_UNKNOWN_ERROR"
         private const val E_UNKNOWN_ERROR_MESSAGE = "Undefined error occurred."
-        private const val GOOGLE_FIT_PERMISSIONS_REQUEST_CODE = 111
+        private const val SIGN_IN_CANCELLED_CODE = 12501
+        private const val SIGN_IN_FAILED_CODE = 12500
+        private const val E_SIGN_IN_FAILED = "E_SIGN_IN_FAILED"
+        private const val SIGN_IN_FAILED_ERROR_MESSAGE =
+            "Error: $SIGN_IN_FAILED_CODE; The sign in attempt didn't succeed with the current account."
     }
 }

--- a/android/src/main/java/com/fitnesstracker/googlefit/GoogleFitManager.kt
+++ b/android/src/main/java/com/fitnesstracker/googlefit/GoogleFitManager.kt
@@ -6,7 +6,10 @@ import com.facebook.react.bridge.*
 import com.fitnesstracker.permission.Permission
 import com.fitnesstracker.permission.PermissionKind
 import com.google.android.gms.auth.api.signin.GoogleSignIn
+import com.google.android.gms.auth.api.signin.GoogleSignInAccount
+import com.google.android.gms.common.api.ApiException
 import com.google.android.gms.fitness.data.DataType
+import com.google.android.gms.tasks.Task
 
 
 class GoogleFitManager(private val reactContext: ReactApplicationContext) : ActivityEventListener {
@@ -35,15 +38,33 @@ class GoogleFitManager(private val reactContext: ReactApplicationContext) : Acti
         data: Intent?
     ) {
         if (requestCode == GOOGLE_FIT_PERMISSIONS_REQUEST_CODE) {
-            if (resultCode == Activity.RESULT_OK) {
-                authorized = true
+            try {
+                /* Checks if correctly setup Google cloud console credentials */
+                val task: Task<GoogleSignInAccount> =
+                    GoogleSignIn.getSignedInAccountFromIntent(data)
+                task.getResult(ApiException::class.java)
 
-                /** Subscribes to tracking steps even if google fit is not installed */
-                if (shouldSubscribeToSteps) recordingApi.subscribe(DataType.TYPE_STEP_COUNT_DELTA)
+                if (resultCode == Activity.RESULT_OK) {
+                    handleSuccessfulLogin()
+                    return
+                }
 
-                authorisationPromise?.resolve(true)
-            } else {
                 authorisationPromise?.resolve(false)
+            } catch (e: ApiException) {
+                val code = e.statusCode
+                val errorCodeMessage = "ErrorCode: $code; "
+                println(errorCodeMessage)
+                if (e.statusCode == 10 || e.statusCode == 12500) {
+                    authorisationPromise?.reject(
+                        E_DEVELOPER_ERROR,
+                        errorCodeMessage + E_DEVELOPER_ERROR_MESSAGE
+                    )
+                } else {
+                    authorisationPromise?.reject(
+                        E_UNKNOWN_ERROR,
+                        errorCodeMessage + E_UNKNOWN_ERROR_MESSAGE
+                    )
+                }
             }
         }
     }
@@ -98,12 +119,26 @@ class GoogleFitManager(private val reactContext: ReactApplicationContext) : Acti
         return activityHistory
     }
 
+    private fun handleSuccessfulLogin() {
+        authorized = true
+
+        /* Subscribes to tracking steps even if google fit is not installed */
+        if (shouldSubscribeToSteps) recordingApi.subscribe(DataType.TYPE_STEP_COUNT_DELTA)
+
+        authorisationPromise?.resolve(true)
+    }
+
     private fun promiseException(promise: Promise?, e: Exception) {
         promise!!.reject(e)
         e.printStackTrace()
     }
 
     companion object {
+        private const val E_DEVELOPER_ERROR = "E_DEVELOPER_ERROR"
+        private const val E_DEVELOPER_ERROR_MESSAGE =
+            "Developer error, please check if you correctly setup SHA1 and Package Name in the Google API console"
+        private const val E_UNKNOWN_ERROR = "E_UNKNOWN_ERROR"
+        private const val E_UNKNOWN_ERROR_MESSAGE = "Undefined error occurred."
         private const val GOOGLE_FIT_PERMISSIONS_REQUEST_CODE = 111
     }
 }

--- a/docs/docs/fundamentals/getting-started.md
+++ b/docs/docs/fundamentals/getting-started.md
@@ -37,15 +37,22 @@ To use HealthKit and Google fit you must first specify that your app requires ac
 Open your project's `Info.plist` and add the following lines inside the outermost `<dict>` tag:
 
 ```xml
-<!-- Fitness tracker -->
-<key>NSMotionUsageDescription</key>
-<string>Reason string goes here</string>
 
-<!-- Health tracker -->
-<key>NSHealthUpdateUsageDescription</key>
-<string>Reason string goes here</string>
-<key>NSHealthShareUsageDescription</key>
-<string>Reason string goes here</string>
+<dict>
+    <!-- ... -->
+
+    <!-- Fitness tracker -->
+    <key>NSMotionUsageDescription</key>
+    <string>Reason string goes here</string>
+
+    <!-- Health tracker -->
+    <key>NSHealthUpdateUsageDescription</key>
+    <string>Reason string goes here</string>
+    <key>NSHealthShareUsageDescription</key>
+    <string>Reason string goes here</string>
+
+    <!-- ... -->
+</dict>
 ```
 
 ## Android
@@ -55,6 +62,7 @@ Open your project's `Info.plist` and add the following lines inside the outermos
 Open your project's AndroidManifest.xml and add the following lines inside the `<manifest>` tag:
 
 ```xml
+
 <uses-permission android:name="android.permission.ACTIVITY_RECOGNITION"/>
 ```
 
@@ -69,7 +77,8 @@ Open your project's AndroidManifest.xml and add the following lines inside the `
 
 4. Fill out next popup forms with a brief explanation why you're using the activity tracker (no need to write much).
 
-5. Go to [Google console](https://console.developers.google.com/flows/enableapi?apiid=fitness&pli=1) (note: select the correct project at the top)
+5. Go to [Google console](https://console.developers.google.com/flows/enableapi?apiid=fitness&pli=1) (note: select the
+   correct project at the top)
 
 6. Select your app's project, `Continue`, and `Go to Credentials`.
 
@@ -77,11 +86,22 @@ Open your project's AndroidManifest.xml and add the following lines inside the `
 
 8. What data will you be accessing? Select `User data` and click next.
 
-9. The **Signing-certificate fingerprint** generation command must be pointed to your app release / staging keystore file.
+9. The **Signing-certificate fingerprint** generation command must be pointed to your app release / staging keystore
+   file.
 
-10. Save and submit everything. If you haven't got your google services config inside your app - download your `google-services.json` file from [Firebase console](https://console.firebase.google.com) and place it inside `android/app` directory within your project.
+10. Save and submit everything. If you haven't got your google services config inside your app - download
+    your `google-services.json` file from [Firebase console](https://console.firebase.google.com) and place it
+    inside `android/app` directory within your project.
 
-:::Note
-For authorization to work in **debug** mode(locally), you must add credentials with debug.keystore.
-For **production** build to work, you must add credentials with SHA-1 key from release.keystore.
+:::important
+For authorization to work in **debug** mode(locally), you must add credentials to Google Console with SHA-1 key from
+debug.keystore.  
+For **production** build to work, you must add credentials to Google Console with SHA-1 key from release.keystore.
+:::
+
+:::caution Google Fit Authorization Error Codes
+**10 - Developer error** - The application is misconfigured, usually meaning the credential setup is incorrect.  
+**12500 - Sign in failed** - The sign in attempt didn't succeed with the current account. This may also occur with the
+incorrect credentials, for example the credentials are deleted from Google Console. But this error code may indicate
+other problems.
 :::

--- a/docs/docs/fundamentals/getting-started.md
+++ b/docs/docs/fundamentals/getting-started.md
@@ -35,6 +35,7 @@ To use HealthKit and Google fit you must first specify that your app requires ac
 ### Adding usage descriptions
 
 Open your project's `Info.plist` and add the following lines inside the outermost `<dict>` tag:
+
 ```xml
 <!-- Fitness tracker -->
 <key>NSMotionUsageDescription</key>
@@ -52,6 +53,7 @@ Open your project's `Info.plist` and add the following lines inside the outermos
 ### Adding permissions
 
 Open your project's AndroidManifest.xml and add the following lines inside the `<manifest>` tag:
+
 ```xml
 <uses-permission android:name="android.permission.ACTIVITY_RECOGNITION"/>
 ```
@@ -79,3 +81,7 @@ Open your project's AndroidManifest.xml and add the following lines inside the `
 
 10. Save and submit everything. If you haven't got your google services config inside your app - download your `google-services.json` file from [Firebase console](https://console.firebase.google.com) and place it inside `android/app` directory within your project.
 
+:::Note
+For authorization to work in **debug** mode(locally), you must add credentials with debug.keystore.
+For **production** build to work, you must add credentials with SHA-1 key from release.keystore.
+:::

--- a/package.json
+++ b/package.json
@@ -1,9 +1,11 @@
 {
   "name": "@kilohealth/rn-fitness-tracker",
   "version": "2.0.7",
-  "description": "GoogleFit & Health tracking package for React Native for Android & iOS",
+  "description": "React native module for tracking fitness data with Google Fit and Apple Health Kit for Android & iOS",
   "keywords": [
     "react-native",
+    "health kit",
+    "google fit",
     "fitness",
     "step",
     "track",
@@ -12,6 +14,7 @@
     "android",
     "ios",
     "healthkit",
+    "apple health",
     "fit",
     "googlefit",
     "fitnessapi"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Throw exception if Google cloud credential setup is incorrect.

<!--- Describe your changes in detail -->

## Motivation and Context

Users get stuck in Google OAuth email select screen and developers don't know that it is setup issue. Before if the setup was incorrect, the authorization result was returned RESULT_CANCELLED, for this reason authorization was false. Now the error returns better error codes, which developers can use to fix their code.
Error codes that can be returned: [GoogleSignInStatusCodes](https://developers.google.com/android/reference/com/google/android/gms/auth/api/signin/GoogleSignInStatusCodes.html) and [CommonStatusCodes](https://developers.google.com/android/reference/com/google/android/gms/common/api/CommonStatusCodes.html)

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

It was tested manually. With the correct credentials and then deleting the credentials.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->
<!--- Add screenshots (if appropriate) -->

## Checklist

- This is a breaking change:
  - [x] Yes
  - [ ] No
- Will this release a new version:
  - [x] Yes
  - [ ] No
