### PR TITLE
FIX: authorisation for android when invoking isTrackingAvailable

### DIFF
--- a/android/src/main/java/com/fitnesstracker/googlefit/GoogleFitManager.kt
+++ b/android/src/main/java/com/fitnesstracker/googlefit/GoogleFitManager.kt
@@ -119,10 +119,15 @@ class GoogleFitManager(private val reactContext: ReactApplicationContext) : Acti
         val fitnessOptions = Helpers.buildFitnessOptionsFromPermissions(permissions)
         val googleAccount = Helpers.getGoogleAccount(reactContext, fitnessOptions)
 
-        return GoogleSignIn.hasPermissions(
+
+        val isTrackingAvailable = GoogleSignIn.hasPermissions(
             googleAccount,
             fitnessOptions
         )
+
+        authorized = isTrackingAvailable
+
+        return isTrackingAvailable
     }
 
     fun getHistoryClient(): HistoryClient {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

It fixed the setting the auth for android. Which never happens when user calls the authorise method
<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
It solve the issue to auth a user and give him access to use the methods. 
<!--- If it fixes an open issue, please link to the issue here. -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->
<!--- Add screenshots (if appropriate) -->

### Checklist

- This is a breaking change:
  - [ ] Yes
  - [x] No
- Will this release a new version:
  - [ ] Yes
  - [x] No
